### PR TITLE
Rename .dockerfile to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,3 @@ FROM nginx:alpine
 COPY --from=build /app/build /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
-


### PR DESCRIPTION
Renamed the build file from .dockerfile to Dockerfile for standard Docker build compatibility. No functional changes to the Dockerfile contents.