### PR TITLE
Add Vite env vars to Dockerfile and debug alert in context

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -2,6 +2,13 @@
 FROM node:18 AS build
 WORKDIR /app
 
+# Definir variables de entorno para Vite
+ARG VITE_API_URL
+ARG VITE_API_KEY
+
+ENV VITE_API_URL=$VITE_API_URL
+ENV VITE_API_KEY=$VITE_API_KEY
+
 # Copiar package.json
 COPY package*.json ./
 

--- a/src/context/context-provider.jsx
+++ b/src/context/context-provider.jsx
@@ -21,6 +21,8 @@ const AppProvider = ({ children }) => {
     apiKey = window.__ENV__?.API_KEY;
   }
 
+  alert(`API URL: ${urlApi}, API KEY: ${apiKey}`);
+
   const [loading, setLoading] = useState(false);
 
   const [dataMaintenance, setDataMaintenance] = useState({


### PR DESCRIPTION
The Dockerfile now accepts VITE_API_URL and VITE_API_KEY as build arguments and sets them as environment variables for Vite. Added a temporary alert in context-provider.jsx to display the API URL and key for debugging purposes.