### PR TITLE
Remove unused ARG instructions from Dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -3,9 +3,6 @@ FROM node:18 AS build
 WORKDIR /app
 
 # Definir variables de entorno para Vite
-ARG VITE_API_URL
-ARG VITE_API_KEY
-
 ENV VITE_API_URL=$VITE_API_URL
 ENV VITE_API_KEY=$VITE_API_KEY
 


### PR DESCRIPTION
Deleted ARG declarations for VITE_API_URL and VITE_API_KEY since they are not required before setting ENV variables. This simplifies the Dockerfile and avoids redundancy.